### PR TITLE
Added configuration of the table name in table storage

### DIFF
--- a/src/WesternDevs.RockyDonut.Api/Infrastructure/Configuration.cs
+++ b/src/WesternDevs.RockyDonut.Api/Infrastructure/Configuration.cs
@@ -5,7 +5,7 @@ namespace WesternDevs.RockyDonut.Api.Infrastructure
 {
     public class Configuration:IConfiguration
     {
-        public string RawSlackMessageTableName => "rawSlackMessage";
+        public string RawSlackMessageTableName => ConfigurationManager.AppSettings["rawMessageTableName"];
         public string AzureStorageConnectionString => ConfigurationManager.AppSettings["AzureStorageConnectionString"];
         public string[] SlackWebhookToken => ConfigurationManager.AppSettings["SlackWebhookToken"].Split(',');
         public string SlackTeamDomain => ConfigurationManager.AppSettings["SlackTeamDomain"];

--- a/src/WesternDevs.RockyDonut.Api/Web.config
+++ b/src/WesternDevs.RockyDonut.Api/Web.config
@@ -14,6 +14,7 @@
     <add key="SlackTeamDomain" value="notset" />
     <add key="SlackTeamId" value="notset" />
     <add key="SlackServiceId" value="notset" />
+    <add key="rawMessageTableName" value="notset"/>
     
   </appSettings>
   <!--


### PR DESCRIPTION
wanted to make the table name a config value so that it can be set by the Azure Application Settings section. This will allow me to create a dev/test environment that is deployed/built off of the dev branch
